### PR TITLE
Throw custom error objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ yarn add @xavdid/json-requests
 
 Usage is intentionally simple. Each method takes a `url` to start and `Options` to end. The `postJSON` method also takes a `body` in middle.
 
-Each method returns a `Promise` that resolves to the JSON response from the server. Each method will also throw an error if the response `status` is `>= 400` (see [error handling](#error-handling)).
+Each method returns a `Promise` that resolves to the JSON response from the server. Each method will also throw an error if the response status is `>= 400` or the response isn't valid JSON. See [error handling](#error-handling)) for more info.
 
 ### getJSON
 
@@ -125,7 +125,7 @@ const withAuth = await getJSON('https://httpbin.org/get', {
 
 ### Error Handling
 
-This package exposes a custom error class, the `ResponseError`. It's thrown in 2 cases:
+This package raises a custom error class, the `ResponseError`. It's thrown in 2 cases:
 
 1. The response content isn't valid JSON
 2. The server returns a status code `>= 400`

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.0
+
+_Released `2023-02-11`_
+
+- Problems with HTTP and JSON parsing now throw custom errors. See the `README` for more info.
+
 ## 0.1.0
 
 _Released `2023-01-23`_

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,59 @@
+type HTTP_ERROR = 'HTTP_ERROR'
+type JSON_PARSE_ERROR = 'JSON_PARSE_ERROR'
+
+type ERROR_CODES = HTTP_ERROR | JSON_PARSE_ERROR
+
+type BodyTypeForCode<Code extends ERROR_CODES> = Code extends HTTP_ERROR
+  ? object
+  : Code extends JSON_PARSE_ERROR
+  ? string
+  : never
+
+export class ResponseError<
+  Code extends ERROR_CODES = ERROR_CODES
+> extends Error {
+  constructor(
+    /**
+     * a human-readable message describing the issue
+     */
+    public message: string,
+    /**
+     * A programatically stable string for narrowing the exact type of error
+     */
+    public code: Code,
+    /**
+     * The HTTP response code
+     */
+    public statusCode: number,
+    /**
+     * As much data as we can get from the body - an object if `JSON.parse` succeeded, or a `string` if it didn't.
+     */
+    public body: BodyTypeForCode<Code>
+  ) {
+    super(message)
+  }
+}
+
+// this type (and accompanying guard) ensure that `.body` is
+// correctly typed in catches
+type BaseErrorShape = Omit<ResponseError, 'code' | 'body'>
+type ResponseErrorLike<Code extends ERROR_CODES = ERROR_CODES> =
+  Code extends ERROR_CODES
+    ? { code: Code; body: BodyTypeForCode<Code> } & BaseErrorShape
+    : never
+
+// util guards
+// created manually for now
+export const isResponseError = (e: unknown): e is ResponseErrorLike => {
+  return e instanceof ResponseError
+}
+
+export const isHTTPError = (
+  error: unknown
+): error is ResponseErrorLike<HTTP_ERROR> =>
+  isResponseError(error) && error.code === 'HTTP_ERROR'
+
+export const isJSONError = (
+  error: unknown
+): error is ResponseErrorLike<JSON_PARSE_ERROR> =>
+  isResponseError(error) && error.code === 'JSON_PARSE_ERROR'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,65 +1,7 @@
-// can remove when fetch is non-experimental
-// maybe Node 20?
-import fetch, { type RequestInit, Headers } from 'node-fetch'
-import { parse, stringify } from 'node:querystring'
+import { sendRequest, type Options } from './request'
 
-const jsonMime = 'application/json'
-
-type METHOD = 'GET' | 'POST' | 'PATCH'
-
-interface Options {
-  // these can only be strings (headers object casts accordingly)
-  headers?: { [k: string]: string }
-  // there might be more types here
-  query?: { [k: string]: string | number | boolean }
-}
-
-const sendRequest = async <Response>(
-  method: METHOD,
-  url: string,
-  // this isn't technically true, but it's fine for our purposes
-  // see https://github.com/sindresorhus/type-fest/blob/1c293f1cd2c1b2e9f95de5001e0c29544a8033b9/source/basic.d.ts#L15-L45
-  // and https://github.com/Microsoft/TypeScript/issues/1897#issuecomment-710744173
-  body?: object,
-  options?: Options
-): Promise<Response> => {
-  // Prep
-  const headers = new Headers({ ...options?.headers })
-
-  // JSON only!
-  headers.set('content-type', jsonMime)
-  headers.set('accept', jsonMime)
-
-  if (options?.query != null) {
-    if (url.includes('?')) {
-      const [baseUrl, qs] = url.split('?', 2)
-      const parsed = parse(qs)
-      url = `${baseUrl}?${stringify({ ...options.query, ...parsed })}`
-    } else {
-      url += `?${stringify(options.query)}`
-    }
-  }
-
-  const payload: RequestInit = {
-    method,
-    headers,
-  }
-
-  if (body != null) {
-    payload.body = JSON.stringify(body)
-  }
-
-  // send request
-  const response = await fetch(url, payload)
-  const data = await response.json()
-
-  if (response.status >= 400) {
-    throw new Error(
-      `Got a ${response.status} response with body ${JSON.stringify(data)}`
-    )
-  }
-  return data as Response
-}
+export { isHTTPError, isJSONError, isResponseError } from './error'
+export { type Options } from './request'
 
 export const getJSON = async <Response extends object>(
   url: string,

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,0 +1,79 @@
+// can remove when fetch is non-experimental
+// maybe Node 20?
+import fetch, { Headers, type RequestInit } from 'node-fetch'
+import { parse, stringify } from 'node:querystring'
+import { ResponseError } from './error'
+
+const jsonMime = 'application/json'
+
+type METHOD = 'GET' | 'POST' | 'PATCH'
+
+export interface Options {
+  // these can only be strings (headers object casts accordingly)
+  headers?: { [k: string]: string }
+  // there might be more types here
+  query?: { [k: string]: string | number | boolean }
+}
+
+export const sendRequest = async <Response>(
+  method: METHOD,
+  url: string,
+  // this isn't technically true, but it's fine for our purposes
+  // see https://github.com/sindresorhus/type-fest/blob/1c293f1cd2c1b2e9f95de5001e0c29544a8033b9/source/basic.d.ts#L15-L45
+  // and https://github.com/Microsoft/TypeScript/issues/1897#issuecomment-710744173
+  body?: object,
+  options?: Options
+): Promise<Response> => {
+  // Prep
+  const headers = new Headers({ ...options?.headers })
+
+  // JSON only!
+  headers.set('content-type', jsonMime)
+  headers.set('accept', jsonMime)
+
+  if (options?.query != null) {
+    if (url.includes('?')) {
+      const [baseUrl, qs] = url.split('?', 2)
+      const parsed = parse(qs)
+      url = `${baseUrl}?${stringify({ ...options.query, ...parsed })}`
+    } else {
+      url += `?${stringify(options.query)}`
+    }
+  }
+
+  const payload: RequestInit = {
+    method,
+    headers,
+  }
+
+  if (body != null) {
+    payload.body = JSON.stringify(body)
+  }
+
+  // send request
+  const response = await fetch(url, payload)
+
+  const bodyText = await response.text() // I _think_ this basically always works (but may not be JSON)
+  let data
+
+  try {
+    data = await JSON.parse(bodyText)
+  } catch {
+    throw new ResponseError(
+      `invalid json response body: "${bodyText}"`,
+      'JSON_PARSE_ERROR',
+      response.status,
+      bodyText
+    )
+  }
+
+  if (response.status >= 400) {
+    throw new ResponseError(
+      `Got a ${response.status} response with body ${JSON.stringify(data)}`,
+      'HTTP_ERROR',
+      response.status,
+      data
+    )
+  }
+  return data as Response
+}

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -102,7 +102,7 @@ try {
   // with basic narrowing
   if (isResponseError(e)) {
     expectType<number>(e.statusCode)
-    expectType<string>(e.code)
+    expectType<'HTTP_ERROR' | 'JSON_PARSE_ERROR'>(e.code)
     expectType<string | object>(e.body)
 
     if (e.code === 'JSON_PARSE_ERROR') {

--- a/test-d/readme-examples.test-d.ts
+++ b/test-d/readme-examples.test-d.ts
@@ -1,7 +1,14 @@
-import { getJSON, postJSON } from '../src'
+import {
+  getJSON,
+  isHTTPError,
+  isJSONError,
+  isResponseError,
+  postJSON,
+} from '../src'
 // ---
 // GET
 
+// ```
 // import { getJSON } from '@xavdid/json-requests'
 
 // within an async function
@@ -19,6 +26,7 @@ const todo = await getJSON<Todo>('https://jsonplaceholder.typicode.com/todos/1')
 console.log(todo.title) // "delectus aut autem"
 
 // POST
+
 // import { postJSON } from '@xavdid/json-requests'
 
 // type Todo = {
@@ -41,8 +49,11 @@ const updatedTodo = await postJSON<Todo>(
 )
 // `todo` is correctly typed
 console.log(updatedTodo.title) // "foo"
+// ```
 
 // OPTIONS
+
+// ```
 // in an async function
 
 // put query params in the object, not the url
@@ -57,3 +68,30 @@ const withAuth = await getJSON('https://httpbin.org/get', {
     authorization: 'Basic eGF2ZGlkOmh1bnRlcjI=',
   },
 })
+// ```
+
+// ERROR HANDLING
+
+// ```
+// import { getJSON, isJSONError, isHTTPError } from '@xavdid/json-requests'
+
+// within an async function
+
+try {
+  await getJSON('https://httpbin.org/xml')
+} catch (e) {
+  if (isJSONError(e)) {
+    e.body // <-- string; response that's not parsable JSON, like "<xml>...</xml>"
+  }
+  if (isHTTPError(e)) {
+    e.body // <-- object; parsed error response, like {error: "unable to X"}
+  }
+
+  if (isResponseError(e)) {
+    // can be either of the above, but not a native error
+    e.message // string; human readable message
+    e.statusCode // number
+    e.code // string; one of the above
+  }
+}
+// ```


### PR DESCRIPTION
Instead of wrapping info in an error string, add info to a custom object which is easier to use. 